### PR TITLE
add Console Input

### DIFF
--- a/Dev/ConsoleInput.hpp
+++ b/Dev/ConsoleInput.hpp
@@ -27,49 +27,38 @@
 //
 //////////////////////////////////////////////////////////////////////////////
 
-#ifndef DEV_CONSOLEOUTPUT_INL
-#define DEV_CONSOLEOUTPUT_INL
+#ifndef DEV_CONSOLEINPUT_HPP
+#define DEV_CONSOLEINPUT_HPP
 
-#include "ConsoleOutput.hpp"
-#include <iostream>
+#include <string>
+#include <vector>
+#include <optional> // requires C++17
+
+#ifdef min
+#undef min
+#endif // min
+#ifdef max
+#undef max
+#endif // max
 
 namespace DEV
 {
 
-inline void print(const std::string& string)
-{
-	std::cout << string << std::flush;
-}
+void pressEnterToContinue(const std::string& message = "Press Enter to continue.");
 
-inline void printLine(const std::string& string)
-{
-	std::cout << string << std::endl;
-}
+std::string inputLine(const std::string& prompt = "", bool newLine = false);
 
-inline void printLine(const std::vector<std::string>& strings)
-{
-	for (auto& string : strings)
-		std::cout << string;
-	std::cout << std::endl;
-}
+template <class T>
+std::optional<T> extractNumberFromString(bool isInteger, const std::string& string);
 
-inline void printLineRepeat(const std::string& string, const unsigned int numberOfLines)
-{
-	for (unsigned int i{ 0 }; i < numberOfLines; ++i)
-		printLine(string);
-}
+template <class T>
+std::optional<T> inputNumber(bool isInteger, const std::string& prompt = "", bool newLine = false);
 
-inline void printLines(const std::vector<std::string>& strings)
-{
-	for (auto& string : strings)
-		printLine(string);
-}
-
-inline void printLines(const unsigned int numberOfLines)
-{
-	printLineRepeat("", numberOfLines);
-}
+template <class T>
+std::optional<T> repeatInputNumberUntilValid(bool isInteger, const std::string& prompt = "", bool newLine = false, const std::string& repeatPrompt = "", const std::vector<std::string>& validBreakawayStrings = {});
 
 } // namespace DEV
 
-#endif // DEV_CONSOLEOUTPUT_INL
+#include "ConsoleInput.inl"
+
+#endif // DEV_CONSOLEINPUT_HPP

--- a/Dev/ConsoleInput.inl
+++ b/Dev/ConsoleInput.inl
@@ -1,0 +1,99 @@
+//////////////////////////////////////////////////////////////////////////////
+//
+// Dev
+//
+// Copyright(c) 2014-2023 M.J.Silk
+//
+// This software is provided 'as-is', without any express or implied
+// warranty. In no event will the authors be held liable for any damages
+// arising from the use of this software.
+//
+// Permission is granted to anyone to use this software for any purpose,
+// including commercial applications, and to alter it and redistribute it
+// freely, subject to the following restrictions :
+//
+// 1. The origin of this software must not be misrepresented; you must not
+// claim that you wrote the original software.If you use this software
+// in a product, an acknowledgment in the product documentation would be
+// appreciated but is not required.
+//
+// 2. Altered source versions must be plainly marked as such, and must not be
+// misrepresented as being the original software.
+//
+// 3. This notice may not be removed or altered from any source distribution.
+//
+// M.J.Silk
+// MJSilk2@gmail.com
+//
+//////////////////////////////////////////////////////////////////////////////
+
+#ifndef DEV_CONSOLEINPUT_INL
+#define DEV_CONSOLEINPUT_INL
+
+#include "ConsoleInput.hpp"
+#include "ConsoleOutput.hpp"
+#include <iostream>
+#include <string>
+#include <limits> // for std::numeric_limits
+
+namespace DEV
+{
+
+inline void pressEnterToContinue(const std::string& message)
+{
+	std::cin.clear();
+	std::cin.sync();
+	print('\n' + message);
+	std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n'); // wait for Enter to be pressed
+}
+
+inline std::string inputLine(const std::string& prompt, const bool newLine)
+{
+	std::string inputString;
+	if (newLine)
+		printLine(prompt);
+	else
+		print(prompt);
+	std::getline(std::cin, inputString);
+	return inputString;
+}
+
+template <class T>
+inline std::optional<T> extractNumberFromString(const bool isInteger, const std::string& string)
+{
+	try
+	{
+		return isInteger ? static_cast<T>(std::stoll(string)) : static_cast<T>(std::stold(string));
+	}
+	catch (...)
+	{
+	}
+	return {};
+}
+
+template <class T>
+inline std::optional<T> inputNumber(const bool isInteger, const std::string& prompt, const bool newLine)
+{
+	std::string inputString{ inputLine(prompt, newLine) };
+	return extractNumberFromString<T>(isInteger, inputString);
+}
+
+template <class T>
+inline std::optional<T> repeatInputNumberUntilValid(const bool isInteger, const std::string& prompt, const bool newLine, const std::string& repeatPrompt, const std::vector<std::string>& validBreakawayStrings)
+{
+	std::optional<T> o;
+	bool firstTime{ true };
+	while (!o)
+	{
+		std::string inputString{ DEV::inputLine(firstTime ? prompt : repeatPrompt, newLine) };
+		if (std::find(validBreakawayStrings.begin(), validBreakawayStrings.end(), inputString) != validBreakawayStrings.end())
+			return std::nullopt;
+		o = DEV::extractNumberFromString<T>(isInteger, inputString);
+		firstTime = false;
+	}
+	return o;
+}
+
+} // namespace DEV
+
+#endif // DEV_CONSOLEINPUT_INL

--- a/Dev/ConsoleOutput.hpp
+++ b/Dev/ConsoleOutput.hpp
@@ -43,7 +43,6 @@
 namespace DEV
 {
 
-void pressEnterToContinue(const std::string& message = "Press Enter to continue.");
 void print(const std::string& string);
 void printLine(const std::string& string = "");
 void printLine(const std::vector<std::string>& strings);

--- a/Dev/all.hpp
+++ b/Dev/all.hpp
@@ -31,6 +31,7 @@
 #define DEV_ALL_HPP
 
 #include "KeepConsoleOpen.hpp"
+#include "ConsoleInput.hpp"
 #include "ConsoleOutput.hpp"
 
 #endif // DEV_ALL_HPP


### PR DESCRIPTION
added ConsoleInput section that allows simple basic console input.

also moved "Press Enter to Continue" function from "output" to "input".

IMPORTANT: this also updates the requirement for this mini-library to a minimum of C++17 due to including the use of optionals.